### PR TITLE
Nodetool access to the Modules

### DIFF
--- a/test/validation/org/apache/cassandra/bridges/Bridge.java
+++ b/test/validation/org/apache/cassandra/bridges/Bridge.java
@@ -20,47 +20,13 @@
  */
 package org.apache.cassandra.bridges;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public abstract class Bridge
 {
-    private static final Logger logger = LoggerFactory.getLogger(Bridge.class);
-
-    protected static final File CASSANDRA_DIR = new File("./");
     protected final Runtime runtime = Runtime.getRuntime();
 
     public abstract void stop();
     public abstract void destroy();
     public abstract String readClusterLogs();
     public abstract void captureLogs(String testName);
-
-    public void nodeTool(int node, String command, String arguments)
-    {
-        try
-        {
-            String fullCommand = "ccm node" + node + " nodetool " + command + " " + arguments;
-            logger.debug("Executing: " + fullCommand);
-            Process p = runtime.exec(fullCommand);
-
-            BufferedReader outReaderOutput = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            String line = outReaderOutput.readLine();
-
-            while (line != null)
-            {
-                System.out.println(line);
-                line = outReaderOutput.readLine();
-            }
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-
-    }
+    public abstract void nodeTool(int node, String command, String arguments);
 }

--- a/test/validation/org/apache/cassandra/bridges/Bridge.java
+++ b/test/validation/org/apache/cassandra/bridges/Bridge.java
@@ -20,10 +20,47 @@
  */
 package org.apache.cassandra.bridges;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class Bridge
 {
+    private static final Logger logger = LoggerFactory.getLogger(Bridge.class);
+
+    protected static final File CASSANDRA_DIR = new File("./");
+    protected final Runtime runtime = Runtime.getRuntime();
+
     public abstract void stop();
     public abstract void destroy();
     public abstract String readClusterLogs();
     public abstract void captureLogs(String testName);
+
+    public void nodeTool(int node, String command, String arguments)
+    {
+        try
+        {
+            String fullCommand = "ccm node" + node + " nodetool " + command + " " + arguments;
+            logger.debug("Executing: " + fullCommand);
+            Process p = runtime.exec(fullCommand);
+
+            BufferedReader outReaderOutput = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line = outReaderOutput.readLine();
+
+            while (line != null)
+            {
+                System.out.println(line);
+                line = outReaderOutput.readLine();
+            }
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+    }
 }

--- a/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
@@ -34,9 +34,6 @@ public class CCMBridge extends Bridge
 {
 
     private int nodeCount;
-    static final File CASSANDRA_DIR = new File("./");
-
-    private final Runtime runtime = Runtime.getRuntime();
     private final File ccmDir;
     private final String DEFAULT_CLUSTER_NAME = "validation";
 

--- a/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
@@ -34,6 +34,7 @@ public class CCMBridge extends Bridge
 {
 
     private int nodeCount;
+    static final File CASSANDRA_DIR = new File("./");
     private final File ccmDir;
     private final String DEFAULT_CLUSTER_NAME = "validation";
 
@@ -133,7 +134,6 @@ public class CCMBridge extends Bridge
             String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;
             logger.debug("Executing: " + fullCommand);
             Process p = runtime.exec(fullCommand, null, CASSANDRA_DIR);
-            int retValue = p.waitFor();
 
             BufferedReader outReaderOutput = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line = outReaderOutput.readLine();
@@ -144,10 +144,6 @@ public class CCMBridge extends Bridge
             }
         }
         catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-        catch (InterruptedException e)
         {
             throw new RuntimeException(e);
         }
@@ -206,4 +202,11 @@ public class CCMBridge extends Bridge
             }
         }
     }
+
+    public void nodeTool(int node, String command, String arguments)
+    {
+        String fullCommand = "ccm node" + node + " nodetool " + command + " " + arguments;
+        executeAndPrint(fullCommand);
+    }
+
 }


### PR DESCRIPTION
The devs need can invoke the nodetool method with following parameters:
  int node(number of node can be either 1,2,3, etc.)
  String command(info, ring, stop, etc.)
  String arguments(-- CLEANUP, -- tokesn, etc. In case no arguments needed for that command, user will  
                              have to type in "" to make it a null argument). I am not sure if there is a better way to  
                              deal with this. Let me know if there is and I can look it up.)

Also, I have moved 'Runtime runtime = Runtime.getRuntime()' to Bridge and made it protected to be accessed by CCMBridge. 
