### PR TITLE
Search for and destroy old clusters on startup

### DIFF
--- a/test/validation/org/apache/cassandra/bridges/ArchiveClusterLogs.java
+++ b/test/validation/org/apache/cassandra/bridges/ArchiveClusterLogs.java
@@ -20,10 +20,13 @@
  */
 package org.apache.cassandra.bridges;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -89,6 +92,26 @@ public class ArchiveClusterLogs
                     zos.closeEntry();
                 }
             }
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void savetempDirectoryPath(File CASSANDRA_DIR, File tmp_Dir)
+    {
+        File filePath = new File(CASSANDRA_DIR + "/build/test/logs/validation/tempDir.txt");
+
+        try
+        {
+            if(!filePath.exists())
+            {
+                filePath.getParentFile().mkdirs();
+            }
+            PrintWriter pw = new PrintWriter(new BufferedWriter(new FileWriter(filePath, true)));
+            pw.println(tmp_Dir);
+            pw.close();
         }
         catch (IOException e)
         {

--- a/test/validation/org/apache/cassandra/bridges/Bridge.java
+++ b/test/validation/org/apache/cassandra/bridges/Bridge.java
@@ -22,7 +22,7 @@ package org.apache.cassandra.bridges;
 
 public abstract class Bridge
 {
-    protected final Runtime runtime = Runtime.getRuntime();
+    protected static final Runtime runtime = Runtime.getRuntime();
 
     public abstract void stop();
     public abstract void destroy();


### PR DESCRIPTION
So the cluster directory is recorded after cluster gets created in tempDir.log.
Before every test run the latest entry from the tempDir.log is retrieved and checked if there are any cluster file present in that directory, if found 'ccm remove' is executed for that directory.  
