### PR TITLE
Return better error message when invalid yaml settings are used

### DIFF
--- a/test/validation/org/apache/cassandra/HarnessTest.java
+++ b/test/validation/org/apache/cassandra/HarnessTest.java
@@ -180,7 +180,7 @@ public class HarnessTest
         }
     }
 
-    public String getTestName(String yamlPath)
+    static String getTestName(String yamlPath)
     {
         Path p = Paths.get(yamlPath);
         String file = p.getFileName().toString();

--- a/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
@@ -88,6 +88,12 @@ public class CCMBridge extends Bridge
 
     public void updateConf(Map<String, String> options)
     {
+        String invalid = checkConfig(options);
+        if(invalid != "")
+        {
+            throw new IllegalArgumentException("The following cassandrayaml parameters are invalid:" + "\n" + invalid);
+        }
+
         for (String key : options.keySet())
             execute("ccm updateconf %s:%s", key, options.get(key));
     }
@@ -272,4 +278,37 @@ public class CCMBridge extends Bridge
         return endpoints;
     }
 
+    public String checkConfig(Map<String, String> parameters)
+    {
+        File filePath = new File(CASSANDRA_DIR + "/conf/cassandra.yaml");
+        String invalid = "";
+
+        for(String key : parameters.keySet()){
+            try
+            {
+                BufferedReader br = new BufferedReader(new FileReader(filePath));
+                String line;
+                int count = 0;
+
+                while((line = br.readLine()) != null)
+                {
+                    if(line.indexOf(key) != -1 && line.indexOf("#") == -1)
+                    {
+                            count += 1;
+                    }
+                }
+
+                if(count < 1)
+                {
+                    invalid += key + "\n";
+                }
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return invalid;
+    }
 }

--- a/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
@@ -88,12 +88,6 @@ public class CCMBridge extends Bridge
 
     public void updateConf(Map<String, String> options)
     {
-        String invalid = checkConfig(options);
-        if(invalid != "")
-        {
-            throw new IllegalArgumentException("The following cassandrayaml parameters are invalid:" + "\n" + invalid);
-        }
-
         for (String key : options.keySet())
             execute("ccm updateconf %s:%s", key, options.get(key));
     }
@@ -276,39 +270,5 @@ public class CCMBridge extends Bridge
         String result = executeAndRead("ccm liveset");
         String[] endpoints = result.split(",");
         return endpoints;
-    }
-
-    public String checkConfig(Map<String, String> parameters)
-    {
-        File filePath = new File(CASSANDRA_DIR + "/conf/cassandra.yaml");
-        String invalid = "";
-
-        for(String key : parameters.keySet()){
-            try
-            {
-                BufferedReader br = new BufferedReader(new FileReader(filePath));
-                String line;
-                int count = 0;
-
-                while((line = br.readLine()) != null)
-                {
-                    if(line.indexOf(key) != -1 && line.indexOf("#") == -1)
-                    {
-                            count += 1;
-                    }
-                }
-
-                if(count < 1)
-                {
-                    invalid += key + "\n";
-                }
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return invalid;
     }
 }


### PR DESCRIPTION
So I have implemented a logic that reads parameters from cassandra.yaml and determines if the parameters in test yamls are valid/invalid. If invalid parameters are found an IllegalArgumentException is thrown which lists the invalid parameters.
