### PR TITLE
Install and start C* using ctool

### DIFF
--- a/test/validation/org/apache/cassandra/HarnessTest.java
+++ b/test/validation/org/apache/cassandra/HarnessTest.java
@@ -40,7 +40,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/test/validation/org/apache/cassandra/bridges/Bridge.java
+++ b/test/validation/org/apache/cassandra/bridges/Bridge.java
@@ -29,8 +29,8 @@ public abstract class Bridge
     public abstract String readClusterLogs(String testName);
     public abstract void captureLogs(String testName);
     public abstract String[] clusterEndpoints();
-    public abstract void nodeTool(int node, String command, String arguments);
-    public abstract void ssTableSplit(int node, String options, String keyspace);
-    public abstract void ssTableMetaData(int node, String keyspace_path);
+    public abstract void nodeTool(String node, String command, String arguments);
+    public abstract void ssTableSplit(String node, String options, String keyspace);
+    public abstract void ssTableMetaData(String node, String keyspace_path);
     public abstract String stress(String options);
 }

--- a/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ccmbridge/CCMBridge.java
@@ -249,7 +249,7 @@ public class CCMBridge extends Bridge
         }
     }
 
-    public void nodeTool(int node, String command, String arguments)
+    public void nodeTool(String node, String command, String arguments)
     {
         String fullCommand;
         if(arguments == "")
@@ -323,7 +323,7 @@ public class CCMBridge extends Bridge
         return endpoints;
     }
 
-    public void ssTableSplit(int node, String options, String keyspace)
+    public void ssTableSplit(String node, String options, String keyspace)
     {
         String fullCommand;
         if(options == "")
@@ -337,7 +337,7 @@ public class CCMBridge extends Bridge
         executeAndPrint(fullCommand);
     }
 
-    public void ssTableMetaData(int node, String keyspace)
+    public void ssTableMetaData(String node, String keyspace)
     {
         String fullCommand;
         if(keyspace == "")


### PR DESCRIPTION
This is without using cstar_perf and running fine for test2.yaml successfully. There needs to be a change in both updateConf() and readClusterLogs() for ctool.

Also, following changes needs to be made in cassandra.yaml before we scp it to the remote nodes so that they could be connected.

"rpc_address: localhost" to be changes to "rpc_address: 0.0.0.0"
"# broadcast_rpc_address: 1.2.3.4" just needs to be not commented
