### PR TITLE
ctool logCapture and logReadError functions

### DIFF
--- a/test/validation/org/apache/cassandra/bridges/ArchiveClusterLogs.java
+++ b/test/validation/org/apache/cassandra/bridges/ArchiveClusterLogs.java
@@ -132,7 +132,7 @@ public class ArchiveClusterLogs
         return file.getAbsolutePath();
     }
 
-    public static boolean countErrors(String errorLogs)
+    public static boolean countErrors(String errorLogs, int nodes)
     {
         int count = 0;
         Pattern p = Pattern.compile("ERROR");
@@ -142,7 +142,7 @@ public class ArchiveClusterLogs
             count++;
         }
 
-        if (count > 6)
+        if (count > nodes * 3)
             return true;
         else
             return false;

--- a/test/validation/org/apache/cassandra/bridges/ctoolbridge/CToolBridge.java
+++ b/test/validation/org/apache/cassandra/bridges/ctoolbridge/CToolBridge.java
@@ -148,7 +148,12 @@ public class CToolBridge extends Bridge
                 combinedResult += result;
             }
         }
-        return  combinedResult;
+
+        if (ArchiveClusterLogs.countErrors(combinedResult, nodeCount))
+            return combinedResult;
+
+        return "";
+
     }
 
     private void execute(String command, Object... args)
@@ -253,12 +258,10 @@ public class CToolBridge extends Bridge
             ArchiveClusterLogs.zipExistingDirectory(existingFolder);
         }
 
-        for(int count = 0; count < nodeCount; count++)
+        for(int count = 1; count <= nodeCount; count++)
         {
-            int logNameCount = count + 1;
-            String sourceFile = "/home/automaton/cassandra/logs/system.log";
-            String destFile = ArchiveClusterLogs.getFullPath(new File(CASSANDRA_DIR + "/build/test/logs/validation/ctoolbridge/" + folderName + "/node" + logNameCount + ".log"), existingFolder);
-
+            String sourceFile = "/home/automaton/fab/cassandra/logs/system.log";
+            String destFile = ArchiveClusterLogs.getFullPath(new File(CASSANDRA_DIR + "/build/test/logs/validation/ctoolbridge/" + folderName + "/node" + count + ".log"), existingFolder);
             execute("ctool scp -r " + DEFAULT_CLUSTER_NAME + " " + count + " " + destFile + " " + sourceFile);
         }
     }
@@ -273,7 +276,7 @@ public class CToolBridge extends Bridge
         }
         else
         {
-            fullCommand = "/home/automaton/cassandra/bin/nodetool -h " + hostname + " " + command + " " + arguments;
+            fullCommand = "/home/automaton/fab/cassandra/bin/nodetool -h " + hostname + " " + command + " " + arguments;
         }
 
         InputStream output = executeRunAndStream(fullCommand, node.getName());


### PR DESCRIPTION
Some minor changes for logCapture and logReader function. CtoolBridge is fully functional with all the logging as in CCM now. However, the node 0 won't have cassandra running on it, so when creating cluster instance, we'll have to use endpoints[] starting from 1 instead of 0. I am thinking of documenting this on README.txt of CToolBridge. 
